### PR TITLE
[CONTENT REVIEW] 18.4 StarWars Datatable - Verificar os testes faltantes de alguns requisitos

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -282,6 +282,7 @@ describe('Não utilize filtros repetidos', () => {
       return child.innerHTML;
     });
     expect(foundColumnFilter).toEqual(expect.arrayContaining(['orbital_period', 'diameter', 'rotation_period', 'surface_water']));
+    expect(foundColumnFilter).toHaveLength(4);
   });
 });
 


### PR DESCRIPTION
Acrescentado teste para o requisito **4. Não utilize filtros repetidos** não dar falso positivo.

[Link do PR do respositorio teste](https://github.com/betrybe/sd-0x-project-starwars-datatable-hooks-tests/pull/5)
[Link PR dos testes de estresse on Stage](https://github.com/betrybe/sd-0x-project-starwars-planets-search-stg/pull/1)
[ISSUE](https://github.com/betrybe/course/issues/2597)